### PR TITLE
Include line break before start of the include

### DIFF
--- a/lib/jsonapi_swagger_helpers.rb
+++ b/lib/jsonapi_swagger_helpers.rb
@@ -113,7 +113,7 @@ module JsonapiSwaggerHelpers
         key :in, :query
         key :type, :string
         key :required, false
-        key :description, "<a href='http://jsonapi.org/format/#fetching-includes'>JSONAPI includes</a>: #{includes}"
+        key :description, "<a href='http://jsonapi.org/format/#fetching-includes'>JSONAPI includes</a>: <br/> #{includes}"
       end
     end
   end


### PR DESCRIPTION
Depending on the first include some of them moving to new line.
some of them are on same line. To be consistent include break
before each include