### PR TITLE
Added stats to swagger docs 

### DIFF
--- a/lib/jsonapi_swagger_helpers.rb
+++ b/lib/jsonapi_swagger_helpers.rb
@@ -33,6 +33,7 @@ module JsonapiSwaggerHelpers
   def jsonapi_index(controller)
     jsonapi_includes(controller, :index)
     jsonapi_filters(controller)
+    jsonapi_stats(controller)
     jsonapi_pagination
     jsonapi_sorting
   end
@@ -65,6 +66,24 @@ module JsonapiSwaggerHelpers
         key :type, :string
         key :required, false
         key :description, "<a href='http://jsonapi.org/format/#fetching-filtering'>JSONAPI filter</a>"
+
+        items do
+          key :model, :string
+        end
+      end
+    end
+  end
+
+  def jsonapi_stats(controller)
+    controller._jsonapi_compliable.stats.each_pair do |stat_name, opts|
+      calculations = opts.calculations.keys - [:keys]
+      calculations = calculations.join('<br/>')
+      parameter do
+        key :name, "stats[#{stat_name}]"
+        key :in, :query
+        key :type, :string
+        key :required, false
+        key :description, "<a href='http://jsonapi.org/format/#document-meta'>JSONAPI meta data</a><br/> #{calculations}"
 
         items do
           key :model, :string

--- a/lib/jsonapi_swagger_helpers/version.rb
+++ b/lib/jsonapi_swagger_helpers/version.rb
@@ -1,3 +1,3 @@
 module JsonapiSwaggerHelpers
-  VERSION = "0.1.3"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
Currently we can configure stats using jsonapi_compliable.
```ruby
jsonapi do
  allow_stat total: [:count]
 end
 ```

 But these are not included in swagger documentation. This pull request
 will includes the stats.