### PR TITLE
Fix TypeNotFound error message: config -> configure

### DIFF
--- a/lib/jsonapi_swagger_helpers/errors.rb
+++ b/lib/jsonapi_swagger_helpers/errors.rb
@@ -12,7 +12,7 @@ Could not find type mapping for payload "#{@payload_name}", key "#{@attribute}".
 
 To add a custom mapping:
 
-JsonapiSwaggerHelpers.config do |c|
+JsonapiSwaggerHelpers.configure do |c|
   c.type_mapping[:string] << MyCustomType
 end
         STR


### PR DESCRIPTION
Just a string change, but will save people some minutes.