### PR TITLE
Raise ArgumentError instead of logging error when passing wrong arg to jsonapi_resource

### DIFF
--- a/lib/jsonapi_swagger_helpers/util.rb
+++ b/lib/jsonapi_swagger_helpers/util.rb
@@ -7,7 +7,7 @@ module JsonapiSwaggerHelpers
       if route
         "#{route[:controller]}_controller".classify.constantize
       else
-        Rails.logger.error("JsonapiSwaggerHelpers: No controller found for #{path}!") unless route
+        raise ArgumentError.new("JsonapiSwaggerHelpers: No controller found for #{path}!")
       end
     end
 


### PR DESCRIPTION
This fix helps the developer experience when you pass a wrong path to jsonapi_resource. Without it you get something like this:
```
NoMethodError in Vpos::DocsController#index
undefined method `action_methods' for true:TrueClass
```
as `controller_for` returns `true` via `Rails.logger` then.

Also the `unless route` is superfluous.