### PR TITLE
Remove uses of `Bignum`

### DIFF
--- a/lib/jsonapi_swagger_helpers/configuration.rb
+++ b/lib/jsonapi_swagger_helpers/configuration.rb
@@ -3,7 +3,7 @@ module JsonapiSwaggerHelpers
     def type_mapping
       @type_mapping ||= {
         string: [String],
-        integer: [Integer, Bignum],
+        integer: [Integer],
         number: [Float],
         boolean: [TrueClass, FalseClass],
         object: [Hash],

--- a/spec/payload_definition_spec.rb
+++ b/spec/payload_definition_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe JsonapiSwaggerHelpers::PayloadDefinition do
     context 'when the payload key has multiple types' do
       it 'returns the first matching type' do
         mapped = described_class
-          .swagger_type_for(:foo, 'myattr', [Bignum, Float])
+          .swagger_type_for(:foo, 'myattr', [Integer, Float])
         expect(mapped).to eq(:integer)
       end
     end


### PR DESCRIPTION
`Bignum` was marked as deprecated starting in Ruby 2.4.0.